### PR TITLE
feat: Add one click checkout demo

### DIFF
--- a/src/components/App.js
+++ b/src/components/App.js
@@ -7,6 +7,7 @@ import CheckoutContainer from './Checkout/CheckoutContainer';
 import StylesContainer from './Styles/StylesContainer';
 import ProductsContainer from './Products/ProductsContainer';
 import SingleProductContainer from './Products/SingleProductContainer';
+import OneClickCheckout from './Checkout/OneClickCheckout';
 import OrderConfirmationContainer from './Orders/OrderConfirmationContainer';
 import NotFound from './global/NotFound';
 // import MobileNav from './global/Mobile/MobileNav';
@@ -27,6 +28,10 @@ const App = props => (
         component={OrderConfirmationContainer}
       />
       <Route path="/product/:id" component={SingleProductContainer} />
+      <Route
+        path="/one-click-checkout/:productId"
+        component={OneClickCheckout}
+      />
       <Route path="*" component={NotFound} />
     </Switch>
 

--- a/src/components/Checkout/OneClickCheckout.js
+++ b/src/components/Checkout/OneClickCheckout.js
@@ -15,7 +15,7 @@ class OneClickCheckout extends Component {
       history.push('/cart');
     }
 
-    const cart = await addToCart(params.productId, 1);
+    await addToCart(params.productId, 1);
 
     history.push('/cart');
   }

--- a/src/components/Checkout/OneClickCheckout.js
+++ b/src/components/Checkout/OneClickCheckout.js
@@ -1,0 +1,36 @@
+import React, { Component } from 'react';
+import { withRouter } from 'react-router';
+import { bindActionCreators } from 'redux';
+import { connect } from 'react-redux';
+
+import LoadingIndicator from '../global/Loading';
+
+import { addToCart } from '../../ducks/cart';
+
+class OneClickCheckout extends Component {
+  async componentDidMount() {
+    const { match: { params }, history, addToCart } = this.props;
+
+    if (!params.productId) {
+      history.push('/cart');
+    }
+
+    const cart = await addToCart(params.productId, 1);
+
+    history.push('/cart');
+  }
+
+  render() {
+    return <LoadingIndicator />;
+  }
+}
+
+const mapDispatchToProps = dispatch =>
+  bindActionCreators(
+    {
+      addToCart
+    },
+    dispatch
+  );
+
+export default connect(null, mapDispatchToProps)(withRouter(OneClickCheckout));

--- a/src/ducks/cart.js
+++ b/src/ducks/cart.js
@@ -55,3 +55,7 @@ export const GetCartItems = () => (dispatch, getState, api) => {
 
   return api.GetCartItems().then(cart => dispatch(fetchCartEnd(cart)));
 };
+
+export const addToCart = (productId, quantity) => (dispatch, getState, api) => {
+  return api.AddCart(productId, quantity);
+};


### PR DESCRIPTION
This allows you to send a link via any channel that adds a product to the cart and redirects you to the checkout.

This is a quick demo and the implementation will most likely change during refactoring later.

`ilovelamp.now.sh/one-click-checkout/{PRODUCT_ID}`

`PRODUCT_ID` must be a I Love Lamp store product.